### PR TITLE
fix conduit socket_type_id error & item_fkey_id error

### DIFF
--- a/datasets/covenant.go
+++ b/datasets/covenant.go
@@ -13,9 +13,9 @@ type Conduit struct {
 	Identifiable
 	Name         LocalizedField `json:"name"`
 	ItemID       int            ``
-	Item         *Item          `json:"item" pg:"rel:has-one"`
+	Item         *Item          `json:"item" pg:"-"`
 	SocketTypeID string         ``
-	SocketType   *SocketType    `json:"socket_type" pg:"rel:has-one"`
+	SocketType   *SocketType    `json:"socket_type" pg:"-"`
 	Ranks        []*ConduitRank `json:"ranks"`
 }
 


### PR DESCRIPTION
Without the has_one relation, there are no errors and the conduit table is updated succesfully